### PR TITLE
Update .info & Readme files for distribution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # exportui
 
-![Screenshot](/images/screenshot.png)
+![Screenshot](/images/ExportUI.git)
 
-(*FIXME: In one or two paragraphs, describe what the extension does and why one would download it. *)
+This extension replaces the screen used to map fields for exports with a more user friendly one.
+
+Key features are the ability to re-order fields easily (missing from the core version) and
+a in-UI display of the how the first few rows of the export will look with the chosen mapping.
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
 ## Requirements
 
-* PHP v5.6+
-* CiviCRM (*FIXME: Version number*)
+* PHP v7.0+
+* CiviCRM 5.18
 
 ## Installation (Web UI)
 
-This extension has not yet been published for installation via the web UI.
+This extension been published for installation via the web UI.
 
 ## Installation (CLI, Zip)
 
@@ -37,8 +40,8 @@ cv en exportui
 
 ## Usage
 
-(* FIXME: Where would a new user navigate to get started? What changes would they see? *)
+When this extension is installed the screen for mapping fields on UI exports will present as the improved
+version. No user action is required.
 
 ## Known Issues
 
-(* FIXME *)

--- a/info.xml
+++ b/info.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0"?>
 <extension key="exportui" type="module">
   <file>exportui</file>
-  <name>FIXME</name>
-  <description>FIXME</description>
+  <name>Export UI</name>
+  <description>Improved interface for export mapping screen</description>
   <license>AGPL-3.0</license>
   <maintainer>
     <author>Coleman Watts</author>
     <email>coleman@civicrm.org</email>
   </maintainer>
   <urls>
-    <url desc="Main Extension Page">http://FIXME</url>
-    <url desc="Documentation">http://FIXME</url>
-    <url desc="Support">http://FIXME</url>
+    <url desc="Main Extension Page">https://civicrm.org/extensions/export-ui</url>
+    <url desc="Documentation">https://github.com/colemanw/exportui/blob/master/README.md</url>
+    <url desc="Support">https://github.com/colemanw/exportui/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-07-04</releaseDate>
+  <releaseDate>2019-10-18</releaseDate>
   <version>1.0</version>
-  <develStage>alpha</develStage>
+  <develStage>stable</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.18</ver>
   </compatibility>
-  <comments>This is a new, undeveloped module</comments>
+  <comments>This extension will, in time, be moved into core to replace the existing screens</comments>
   <civix>
     <namespace>CRM/Exportui</namespace>
   </civix>


### PR DESCRIPTION
I have added an extension page here
https://civicrm.org/extensions/export-ui

and with these changes we should be able to publish a downloadable release.

I would like to see us start to plan towards having this ship-enabled & then being moved into
core but we should probably get a 'proper' release out there as our first step.

We have hit no problems in production. I'm not 100% sure of the minimum version - since we are using on
5.18 and it is the current stable as well. I would expect us to increment the version
if we make any improvements & don't see any benefit in figuring out the technical minimum